### PR TITLE
Fix two release blockers: stale CI test path, and a subpackage missing from the wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install core only
         run: pip install -e . pytest
       - name: Core tests
-        run: python -m pytest -q tests/test_races.py tests/test_probit.py tests_thurstone
+        run: python -m pytest -q tests/test_races.py tests/test_probit.py tests_research
 
   package:
     # What gets SHIPPED, not what is in the tree. setup.py lists packages

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "Programming Language :: Python :: 3.13",
     ],
     python_requires=">=3.10",
-    packages=["winning", "winning.classic", "winning.factor", "winning.methods", "winning.bench", "winning.research", "winning.probit", "winning.ratings"],
+    packages=["winning", "winning.classic", "winning.factor", "winning.methods", "winning.bench", "winning.research", "winning.probit", "winning.ratings", "winning.alternatives"],
     test_suite='pytest',
     tests_require=['pytest','pandas','scipy>=1.7.3','randomcov'],
     include_package_data=True,


### PR DESCRIPTION
## Summary

Found while preparing to publish `winning` 1.5.0 / `fastrace` 0.2.0 (needed by the exp44 image-watermark experiment in `photo-finish-watermarking`, which is stuck on the stale PyPI 1.4.0/0.1.2 pair). `main` has been CI-red for a few days for two reasons unrelated to that work:

- **Stale CI path**: the `thurstone` -> `research` rename (`58cc19b`) moved `tests_thurstone/` to `tests_research/` and updated `setup.py`/`pytest.ini`/`README.md`, but missed the hardcoded path in `ci.yml`'s `test-minimal` job, which has failed `file or directory not found: tests_thurstone` on every push since.
- **Packaging bug**: `winning.alternatives` (shipped in `b7f279f`/`10f9ee8`, the alternatives page) was never added to `setup.py`'s explicit `packages=` list, so every wheel built from `main` right now silently omits it.

Both are one-line fixes.

## Test plan

- [x] Full suite green locally: `python -m pytest -q tests/test_races.py tests/test_probit.py tests_research` -> 268 passed, 2 skipped
- [x] Built the wheel and confirmed `winning/alternatives/__init__.py` is present
- [x] `package` job's own source-vs-shipped check now matches (9 subpackages both sides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eL1ES7kJa6ssyDUqLQxrY