### PR TITLE
Fix probit.fit_factor_model: an identity covariance is an independent race (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Fixed `winning.probit.fit_factor_model`, and so `shares(..., Sigma=,
+  k=)` and `utilities_from_shares(..., Sigma=, k=)`: the contrast
+  heuristic applied principal-factor analysis to P Sigma P although the
+  idiosyncratic part in contrast space, P diag(D) P, is not diagonal,
+  so an independent race (Sigma = I, k = 1) came back with an invented
+  factor and shares off by 0.03-0.05. The wrapper now uses the
+  projected fit (`factor_model_projected`), which reproduces the
+  contrast covariance exactly; the issue's example agrees with
+  independent quadrature to 3e-10. Found independently while
+  evaluating Bernd Johannes Wuebben's gaussian-correlated-choice (#27).
 - Ordered finishing prefixes: `ordered_probabilities(mu, k, ...)` prices
   every ordered k-prefix (exacta/trifecta-style permutations) from one
   shared field pass, with a Rust kernel (`ordered_prefixes`);

--- a/tests/test_probit.py
+++ b/tests/test_probit.py
@@ -51,3 +51,61 @@ def test_zero_factor_default_is_independent_probit():
     p = shares(u)                      # V=None -> independent, unit variance
     assert abs(p.sum() - 1) < 1e-12
     assert (np.argsort(p) == np.argsort(u)).all()
+
+
+def _independent_reference(u):
+    """Independent Gaussian shares by one-dimensional quadrature."""
+    from scipy.integrate import quad
+    from scipy.stats import norm
+    return np.array([
+        quad(lambda x: norm.pdf(x - u[i]) * np.prod(norm.cdf(x - np.delete(u, i))),
+             -np.inf, np.inf, epsabs=1e-11, epsrel=1e-11)[0]
+        for i in range(len(u))])
+
+
+def test_identity_covariance_is_an_independent_race():
+    # issue #27: the contrast heuristic applied principal-factor analysis
+    # to P Sigma P, whose idiosyncratic part P diag(D) P is not diagonal,
+    # and invented a factor from the centring artefact (shares off by
+    # 0.03-0.05 on this example); the projected fit returns V = 0
+    u = np.array([0.6, -0.1, -0.5])
+    got = shares(u, Sigma=np.eye(3), k=1)
+    assert np.abs(got - _independent_reference(u)).max() < 1e-6
+    # the identified object is P Sigma P; the loading orientation is a
+    # gauge (V V' + diag D may differ from Sigma by 1 c' + c 1'), so the
+    # representation is checked through the contrast covariance
+    V, D = fit_factor_model(np.eye(3), 1)
+    P = np.eye(3) - np.ones((3, 3)) / 3
+    assert np.abs(P @ (V @ V.T + np.diag(D) - np.eye(3)) @ P).max() < 1e-8
+
+
+def test_diagonal_covariances_keep_their_contrast_covariance_and_shares():
+    rng = np.random.default_rng(3)
+    n = 5
+    u = rng.normal(size=n)
+    d = rng.uniform(0.4, 2.5, n)
+    P = np.eye(n) - np.ones((n, n)) / n
+    for Sigma in (np.eye(n), np.diag(d)):
+        for k in (1, 2):
+            V, D = fit_factor_model(Sigma, k)
+            fitted = V @ V.T + np.diag(D)
+            assert np.abs(P @ (fitted - Sigma) @ P).max() < 1e-8
+            p_sigma = shares(u, Sigma=Sigma, k=k)
+            p_direct = shares(u, D=np.diag(Sigma))          # V = None: independent
+            assert np.abs(p_sigma - p_direct).max() < 1e-6   # quadrature paths differ
+            # a permutation of the alternatives permutes the shares
+            perm = rng.permutation(n)
+            p_perm = shares(u[perm], Sigma=Sigma[np.ix_(perm, perm)], k=k)
+            assert np.abs(p_perm - p_sigma[perm]).max() < 1e-6
+
+
+def test_sigma_path_forward_and_inverse_round_trip():
+    u, V, D = _problem()
+    Sigma = V @ V.T + np.diag(D)
+    p = shares(u, Sigma=Sigma, k=2)
+    u_hat = utilities_from_shares(p, Sigma=Sigma, k=2)
+    assert np.abs(u_hat - (u - u.mean())).max() < 1e-4
+    # the fitted representation reproduces the contrast covariance
+    Vf, Df = fit_factor_model(Sigma, 2)
+    P = np.eye(len(u)) - np.ones((len(u), len(u))) / len(u)
+    assert np.abs(P @ (Vf @ Vf.T + np.diag(Df) - Sigma) @ P).max() < 1e-6

--- a/winning/factor/core.py
+++ b/winning/factor/core.py
@@ -126,6 +126,18 @@ def factor_model_contrast(C: np.ndarray, k: int, n_iter: int = 200,
     fit, not be refit against diag(C). Loadings are centered (P V) and
     canonicalized by SVD with a sign convention, making results reproducible
     at the covariance level rather than the supplied-V level.
+
+    CAVEAT (issue #27, 2026-09-11): this is a heuristic, and on inputs
+    close to a diagonal it is wrong, not merely approximate. Principal-
+    factor analysis assumes the idiosyncratic part is diagonal, but in
+    contrast space it is P diag(D) P, which is not; for C = I with k = 1
+    the iteration reads the centring artefact as a factor and the
+    resulting race is materially correlated (shares off by 0.03-0.05).
+    The public covariance intake (winning.probit.fit_factor_model,
+    fit_covariance) uses factor_model_projected, which minimises the
+    projected residual exactly. This function is retained because the
+    boundary experiments (research/experiments/exp14_boundaries) cite
+    it; prefer factor_model_projected for anything new.
     """
     C = np.asarray(C, dtype=float)
     n = len(C)

--- a/winning/probit/__init__.py
+++ b/winning/probit/__init__.py
@@ -10,7 +10,7 @@ winning.factor.races, where the reflection is the caller's business).
     shares(utilities, V=V, D=D)          all N choice probabilities
     utilities_from_shares(p, V=V, D=D)   the paper's calibration
     shares(utilities, Sigma=Sigma, k=2)  supplied covariance: fits the
-                                         certified contrast factor model
+                                         contrast-space factor model
                                          first (return_fit=True to get
                                          the fitted V, D back)
 """
@@ -20,7 +20,7 @@ from __future__ import annotations
 import numpy as np
 
 from ..factor.core import (abilities_from_probabilities_factor,
-                           factor_model_contrast, hermite_nodes,
+                           factor_model_projected, hermite_nodes,
                            win_probabilities_factor)
 
 __all__ = ["shares", "utilities_from_shares", "calibrate_utilities",
@@ -28,9 +28,32 @@ __all__ = ["shares", "utilities_from_shares", "calibrate_utilities",
 
 
 def fit_factor_model(Sigma, k):
-    """Certified contrast-space factor fit: Sigma ~ V V' + diag(D) on the
-    choice-relevant quotient. Returns (V, D)."""
-    return factor_model_contrast(np.asarray(Sigma, dtype=float), k)
+    """Contrast-space factor fit: Sigma ~ V V' + diag(D) on the
+    choice-relevant quotient, i.e. minimising ||P (Sigma - V V' - diag D)
+    P||_F with P the centring projection. Returns (V, D) with V centred
+    (P V = V) and canonicalised (SVD, sign convention), so results are
+    reproducible at the covariance level; the fit is a certified
+    alternation (factor_model_projected), not a global certificate.
+
+    Until 2026-09-11 this called factor_model_contrast, which applies
+    ordinary principal-factor analysis to P Sigma P although the
+    idiosyncratic part in contrast space, P diag(D) P, is not diagonal:
+    for an INDEPENDENT race (Sigma = I, k = 1) it invented a factor from
+    the centring artefact and moved the shares by 0.03-0.05 (issue #27).
+    The projected fit returns V = 0, D = diag(Sigma) there, exactly.
+    """
+    Sigma = np.asarray(Sigma, dtype=float)
+    n = len(Sigma)
+    V, D = factor_model_projected(Sigma, k)
+    P = np.eye(n) - np.ones((n, n)) / n
+    V = P @ V
+    A, sv, _ = np.linalg.svd(V, full_matrices=False)
+    V = A[:, :k] * sv[:k]
+    for j in range(V.shape[1]):
+        i0 = np.argmax(np.abs(V[:, j]))
+        if V[i0, j] < 0:
+            V[:, j] = -V[:, j]
+    return V, D
 
 
 def _prepare(n, V, D, Sigma, k):

--- a/winning/probit/__init__.py
+++ b/winning/probit/__init__.py
@@ -44,7 +44,16 @@ def fit_factor_model(Sigma, k):
     """
     Sigma = np.asarray(Sigma, dtype=float)
     n = len(Sigma)
-    V, D = factor_model_projected(Sigma, k)
+    # the alternation is nonconvex and its default start (a constant
+    # idiosyncratic variance) can stall short of the exact solution on
+    # some platforms even for a diagonal Sigma (CI, 2026-09-11: residual
+    # 3e-3 on ubuntu, 1e-15 on macOS); starting from D0 = diag(Sigma)
+    # reaches a diagonal exactly in one sweep, so both starts are run
+    # and the lower projected residual kept
+    from ..factor.core import _projected_sq
+    fits = [factor_model_projected(Sigma, k, D0=np.diag(Sigma)),
+            factor_model_projected(Sigma, k)]
+    V, D = min(fits, key=lambda vd: _projected_sq(Sigma, vd[0], vd[1]))
     P = np.eye(n) - np.ones((n, n)) / n
     V = P @ V
     A, sv, _ = np.linalg.svd(V, full_matrices=False)


### PR DESCRIPTION
Fixes #27.

`winning.probit.fit_factor_model` (and so `shares(..., Sigma=, k=)` and `utilities_from_shares(..., Sigma=, k=)`) called `factor_model_contrast`, which applies principal-factor analysis to `P Sigma P` although the idiosyncratic part in contrast space, `P diag(D) P`, is not diagonal. For `Sigma = I`, `k = 1` it invented a factor from the centring artefact: shares off by 0.029 on this tree (0.045 in the report) against the independent race.

The wrapper now uses `factor_model_projected`, which minimises the projected residual and reproduces the contrast covariance exactly; loadings stay centred and canonicalised.

Acceptance, as stated in the issue:
- the reproduction agrees with independent one-dimensional quadrature to 3e-10 (mark 1e-6);
- identity and heterogeneous diagonal covariances preserve their contrast covariance (`P C P` residual < 1e-8) and their shares (within 1e-6 of the `V=None` path), including under a permutation of alternatives;
- forward and inverse paths both exercised (round trip to 1e-4 through `Sigma=`);
- covariance equivalence is tested through `P C P` and probabilities, not a loading orientation, which is a gauge of the identified object.

Found independently while evaluating Bernd Johannes Wuebben's gaussian-correlated-choice (#25); this report is not attributed to him.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196s5aukyUYtspqTVApwBme