### PR TITLE
Honour the factor node count at rank >= 3 (nodes_log2 on the correlated updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- `Qf` was silently ignored by the correlated updates at factor rank
+  >= 3 (`_factor_nodes` hard-coded 1024 Sobol nodes there), so it did
+  nothing in exactly the regime a user would reach for it (found by the
+  bandits session: Qf 2..7 bit-identical at r = 10). The node count at
+  rank >= 3 is now `nodes_log2` (default 10, the historical count) on
+  `update_winner_correlated`, `update_order_correlated`, `update_race`,
+  `ranking_loglik_and_score`, `predictive_win_probabilities` and
+  `AbilityTracker`; docstrings say which parameter applies at which
+  rank, and the tracker's records the measured cost ceiling of block
+  correlation at double-digit group counts (15-29 s per update for a
+  20-entrant field with ten pairs).
 - Factor ratings (`winning.ratings.factor_ratings`): an entity's
   ability as a vector over observed conditions, MAP through the exact
   ranking likelihood. `fit_factor_ratings(events, n_entities, n_cov,

--- a/research/chess/README.md
+++ b/research/chess/README.md
@@ -168,6 +168,9 @@ failures are kept because they are the transfer conditions:
 | `exp31_chess_giant_killers.py` | registered, unrun |
 | `exp32_style_heteroskedastic.py` | the K=2 factor projection |
 | `exp35_vs_glicko2.py` | the real Glicko-2 comparison |
+| `exp36_colour_confound.py` | is the estimator column just colour? |
+| `exp37_sparse_players.py` | robustness across density thresholds |
+| `exp38_modern_month.py` | 2024-01 replication: registered, unrun |
 | `results/` | per-game losses and raw outputs |
 
 Data is one month of the Lichess open database
@@ -177,6 +180,32 @@ it. Estimators import `winning.ratings.factor_ratings`; the originals
 used the bandits reference implementation and were swapped on the
 move, with `exp30` re-run afterwards to confirm the numbers reproduce.
 
-**Open:** all of this is one month of 2013. A modern month has orders
-of magnitude more players and a Lichess rating system that has since
-evolved. That replication is the obvious next step and is not done.
+**Open:** the modern replication is **registered and data-ready, not
+yet run** (`exp38_modern_month.py`). 2024-01 is cached as a contiguous
+4,000,000-game prefix — 765,053 players, 4,389 with ≥100 games against
+639 in 2013. Two things are already known from the cache alone, before
+any model is fitted:
+
+- **Classical chess has collapsed.** The time-control mix went from
+  classical 34% / blitz 38% / bullet 27% in 2013-01 to classical
+  **0.6%** / blitz 48% / bullet 37% in 2024-01 — 24,756 games out of
+  four million. The 2013 design used classical as the model's base
+  category, which is no longer defensible, so `exp38` moves the base
+  to blitz. This changes no games and no split, and fitted ability
+  differences are invariant to the reference level, so it cannot
+  favour an arm.
+- **The dimension itself is thinner now.** A population concentrated
+  into two adjacent fast controls has less time-control style
+  structure to find than one spread across three. `exp38` therefore
+  pre-registers a *smaller* margin than 2013's −0.0161, and says so
+  before running rather than after.
+
+`loader.py` now streams the HTTP response straight into the zstd
+decoder and takes a cap, because a modern month is ~32 GB compressed
+and the original loader read the whole file into memory. The cache
+filename records the cap
+(`lichess_2024_01_first4000000_headers.parquet`) so a truncated month
+cannot be mistaken for a whole one.
+
+    python research/chess/loader.py 2024-01 4000000
+    python research/chess/exp38_modern_month.py

--- a/research/chess/exp38_modern_month.py
+++ b/research/chess/exp38_modern_month.py
@@ -1,0 +1,206 @@
+"""exp38: does the Lichess result replicate on a modern month?
+
+The largest hole in the chess result: everything so far is 2013-01,
+639 players, an early-adopter population, and a rating system Lichess
+has since changed. This replicates on 2024-01.
+
+DATA. The month is ~32 GB compressed, so loader.py streams it with
+early termination: the first 4,000,000 games, a contiguous opening
+window of the month rather than a sample. 765,053 distinct players;
+4,389 with >= 100 games, against 639 in 2013. The cache filename
+records the cap so a truncated month cannot be mistaken for a whole
+one.
+
+    python research/chess/loader.py 2024-01 4000000
+
+A DESIGN CHANGE FORCED BY THE DATA, not by preference. The time-control
+mix has shifted drastically:
+
+    2013-01   classical 34%   blitz 38%   bullet 27%
+    2024-01   classical 0.6%  blitz 48%   bullet 37%
+
+Classical has all but vanished (24,756 games of 4,000,000). Since the
+2013 design used classical as the BASE category, keeping it would put
+the model's reference level on a category with almost no data. The
+base is therefore blitz -- the plurality -- with offsets for bullet
+and classical. The classical offset is expected to be poorly
+estimated; that is a fact about modern Lichess, and it is reported
+rather than hidden by dropping the category.
+
+Note what this change does NOT do: it does not alter which games enter
+the comparison, and every arm -- Glicko-2 pooled, Glicko-2 per time
+control, our scalar, our factor -- sees exactly the same games and the
+same split. Changing the reference level of a saturated set of
+category offsets cannot favour an arm, because the fitted ability
+differences are invariant to it.
+
+PRE-REGISTERED PREDICTIONS:
+  P1. The factor rating still beats glicko2-per-TC, CI excluding zero.
+  P2. The margin is SMALLER than 2013's 0.0161. Two reasons pull that
+      way: with classical nearly gone the population is more
+      homogeneous in time control, so there is less style structure to
+      find; and a 7x larger player pool means more data per parameter
+      for every arm, which helps the competitor too.
+  P3. The estimator/structure split still favours the estimator
+      (2013: ~80% estimator, ~20% structure).
+  FALSIFICATION: if the factor rating does not beat glicko2-per-TC on
+  modern data, the headline is a 2013 artifact and must be restated as
+  such.
+
+Run:  python research/chess/exp38_modern_month.py
+"""
+from __future__ import annotations
+import importlib.util, os, sys, types
+import numpy as np, pandas as pd
+from winning import race_probabilities
+from winning.ratings.factor_ratings import fit_design_ratings as linear_ability_map
+
+
+def _load_glicko():
+    """Glicko-2 lives in src/winning/, a separate source tree from the
+    installed package, so `import winning.glicko2` does not work. It is
+    loaded by path. (A previous edit "simplified" this to a direct
+    import; the shim is load-bearing.)"""
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo = os.path.dirname(os.path.dirname(here))
+    roots = [os.path.join(repo, "src", "winning"),
+             os.path.expanduser("~/github/winning/src/winning")]
+    root = next((r for r in roots if os.path.isdir(r)), None)
+    if root is None:
+        raise ImportError(f"glicko2 source tree not found in {roots}")
+    pkg = types.ModuleType("wsrc"); pkg.__path__ = [root]
+    sys.modules["wsrc"] = pkg
+    for n in ("ratingsystem", "glicko2"):
+        spec = importlib.util.spec_from_file_location(
+            f"wsrc.{n}", os.path.join(root, n + ".py"))
+        m = importlib.util.module_from_spec(spec)
+        sys.modules[f"wsrc.{n}"] = m; setattr(pkg, n, m)
+        spec.loader.exec_module(m)
+    from wsrc.glicko2 import Glicko2Rating
+    return Glicko2Rating
+
+
+Glicko2Rating = _load_glicko()
+HERE = os.path.dirname(os.path.abspath(__file__))
+CACHE = os.path.expanduser(
+    "~/.cache/winning/lichess_2024_01_first4000000_headers.parquet")
+TCS = ["blitz", "bullet", "classical"]      # blitz is the BASE now
+MIN_GAMES = 100
+SEED = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+
+if not os.path.exists(CACHE):
+    raise SystemExit(
+        f"missing {CACHE}\nrun: python research/chess/loader.py 2024-01 4000000")
+
+df = pd.read_parquet(CACHE)
+df = df[df.result.isin(["1-0", "0-1"])]
+ev = df.event.str.lower()
+tcn = np.where(ev.str.contains("bullet"), "bullet",
+      np.where(ev.str.contains("blitz"), "blitz",
+      np.where(ev.str.contains("classical"), "classical", "other")))
+m = tcn != "other"
+df = df[m].reset_index(drop=True); tcn = tcn[m]
+cnt = pd.concat([df.white, df.black]).value_counts()
+keep = set(cnt[cnt >= MIN_GAMES].index)
+m2 = (df.white.isin(keep) & df.black.isin(keep)).values
+df = df[m2].reset_index(drop=True); tcn = tcn[m2]
+players = sorted(keep); pidx = {p: i for i, p in enumerate(players)}
+Mp = len(players)
+tci = pd.Series(tcn).map({t: i for i, t in enumerate(TCS)}).values
+w = df.white.map(pidx).values; b = df.black.map(pidx).values
+won = (df.result == "1-0").values
+n = len(df)
+print(f"2024-01 (first 4M games): {n} dense decisive games, {Mp} players")
+print(f"  TC mix: {pd.Series(tcn).value_counts(normalize=True).round(4).to_dict()}")
+rng = np.random.default_rng(SEED); perm = rng.permutation(n)
+ntr, nva = int(n * .50), int(n * .25)
+tr = np.sort(perm[:ntr])
+va = np.sort(perm[ntr:ntr + nva])
+te = np.sort(perm[ntr + nva:])
+print(f"  split seed {SEED}: train {len(tr)} val {len(va)} TEST {len(te)}",
+      flush=True)
+P, NG = 3, 1 + len(TCS)
+
+
+def xvec(t):
+    return np.array([1.0, float(tci[t] == 1), float(tci[t] == 2)])
+
+
+def glicko(fit, ev_, tau, per_tc):
+    S = ({c: Glicko2Rating(tau=tau) for c in range(len(TCS))} if per_tc
+         else {0: Glicko2Rating(tau=tau)})
+    for t in fit:
+        S[tci[t] if per_tc else 0].observe(
+            [players[w[t]], players[b[t]]], [1, 2] if won[t] else [2, 1], 1.0)
+    out = []
+    for t in ev_:
+        p = np.asarray(S[tci[t] if per_tc else 0].win_probabilities(
+            [players[w[t]], players[b[t]]]), dtype=float)
+        p = np.clip(p, 1e-12, None); p /= p.sum()
+        out.append(-np.log(p[0] if won[t] else p[1]))
+    return np.array(out)
+
+
+def ours(fit, ev_, lam, scalar=False):
+    pp = 1 if scalar else P
+    width = Mp * pp + NG
+    evs = []
+    for t in fit:
+        x = xvec(t)[:pp]; Z = np.zeros((2, width))
+        Z[0, w[t] * pp:w[t] * pp + pp] = x
+        Z[1, b[t] * pp:b[t] * pp + pp] = x
+        Z[0, Mp * pp] = 1.0; Z[0, Mp * pp + 1 + tci[t]] = 1.0
+        evs.append((Z, np.array([0, 1]) if won[t] else np.array([1, 0])))
+    v = np.full(width, 1.0)
+    if not scalar:
+        v[np.concatenate([np.arange(Mp) * P + 1, np.arange(Mp) * P + 2])] = lam
+    v[Mp * pp] = 0.1; v[Mp * pp + 1:] = 1.0
+    th = linear_ability_map(evs, width, ridge=v)
+    out = []
+    for t in ev_:
+        x = xvec(t)[:pp]
+        mu_w = th[w[t] * pp:w[t] * pp + pp] @ x + th[Mp * pp] + th[Mp * pp + 1 + tci[t]]
+        mu_b = th[b[t] * pp:b[t] * pp + pp] @ x
+        p = np.asarray(race_probabilities(-np.array([mu_w, mu_b]), D=np.ones(2)))
+        p = np.clip(p, 1e-12, None); p /= p.sum()
+        out.append(-np.log(p[0] if won[t] else p[1]))
+    return np.array(out)
+
+
+res = {}
+for lbl, per in (("glicko2 pooled", False), ("glicko2 per TC", True)):
+    best = min(((glicko(tr, va, t, per).mean(), t) for t in (0.3, 0.5)))
+    res[lbl] = glicko(tr, te, best[1], per)
+    print(f"  {lbl:16s} TEST {res[lbl].mean():.4f}  (tau {best[1]})", flush=True)
+best = min(((ours(tr, va, l, True).mean(), l) for l in (1.0, 3.0)))
+res["our scalar"] = ours(tr, te, best[1], True)
+print(f"  {'our scalar':16s} TEST {res['our scalar'].mean():.4f}", flush=True)
+best = min(((ours(tr, va, l).mean(), l) for l in (3.0, 10.0, 30.0)))
+res["factor"] = ours(tr, te, best[1])
+edge = "  <-- grid edge" if best[1] in (3.0, 30.0) else ""
+print(f"  {'factor':16s} TEST {res['factor'].mean():.4f}  (ridge {best[1]})"
+      f"{edge}", flush=True)
+
+ids = np.random.default_rng(1).integers(0, len(te), (20000, len(te)))
+
+
+def cmp(a, bb):
+    d = (res[a][ids] - res[bb][ids]).mean(1)
+    lo, hi = np.percentile(d, [2.5, 97.5])
+    print(f"  {a} vs {bb}: {res[a].mean()-res[bb].mean():+.4f} "
+          f"[{lo:+.4f},{hi:+.4f}]  P(better) {np.mean(d<0):.3f}")
+
+
+print("\n  --- headline (P1): factor vs Lichess's deployed architecture ---")
+cmp("factor", "glicko2 per TC")
+print("  --- decomposition (P3) ---")
+cmp("our scalar", "glicko2 pooled")      # estimator
+cmp("factor", "our scalar")              # structure
+cmp("glicko2 pooled", "glicko2 per TC")  # does stratification help Glicko-2?
+d = res["factor"].mean() - res["glicko2 per TC"].mean()
+print(f"\n  P2 wants |{d:+.4f}| < 0.0161 (2013's margin): "
+      f"{'CONFIRMED' if abs(d) < 0.0161 else 'FAILED'}")
+out = os.path.join(HERE, "results", f"exp38_modern_2024_seed{SEED}.csv")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+pd.DataFrame(res).to_csv(out, index=False)
+print(f"  per-game losses -> {out}")

--- a/research/chess/loader.py
+++ b/research/chess/loader.py
@@ -4,15 +4,31 @@ One month of the Lichess open database (database.lichess.org, CC0),
 streamed and reduced to headers only: ~380MB of PGN becomes a 1MB
 parquet. Idempotent; skips the download if the cache exists.
 
-Run:  python research/chess/loader.py [YYYY-MM]
+MODERN MONTHS NEED THE CAP. 2013-01 is 380MB compressed and fits in
+memory; 2024-01 is ~32GB and does not. This now streams the HTTP
+response straight into the zstd decoder rather than reading it into a
+bytes object first, and takes an optional cap so a modern month can be
+stopped early:
+
+    python research/chess/loader.py 2013-01
+    python research/chess/loader.py 2024-01 4000000
+
+A capped run is a contiguous PREFIX of the month, not a sample, and the
+cache filename records the cap ("..._first4000000_headers.parquet") so
+a truncated month can never be mistaken for a whole one.
+
+Run:  python research/chess/loader.py [YYYY-MM] [MAX_GAMES]
 """
 from __future__ import annotations
-import collections, io, os, re, sys, urllib.request
+import io, os, re, sys, urllib.request
 import pandas as pd, zstandard
 
 MONTH = sys.argv[1] if len(sys.argv) > 1 else "2013-01"
+MAX_GAMES = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+_tag = f"_first{MAX_GAMES}" if MAX_GAMES else ""
 CACHE = os.path.expanduser(
-    f"~/.cache/winning/lichess_{MONTH.replace('-', '_')}_headers.parquet")
+    f"~/.cache/winning/lichess_{MONTH.replace('-', '_')}{_tag}"
+    f"_headers.parquet")
 URL = (f"https://database.lichess.org/standard/"
        f"lichess_db_standard_rated_{MONTH}.pgn.zst")
 
@@ -21,13 +37,14 @@ def main():
         print(f"cached already: {CACHE}")
         return
     os.makedirs(os.path.dirname(CACHE), exist_ok=True)
-    print(f"fetching {URL}")
-    raw = urllib.request.urlopen(
+    print(f"fetching {URL}"
+          + (f" (stopping after {MAX_GAMES} games)" if MAX_GAMES else ""))
+    resp = urllib.request.urlopen(
         urllib.request.Request(URL, headers={"User-Agent": "winning-research"}),
-        timeout=900).read()
-    print(f"  {len(raw)/1e6:.1f} MB compressed; streaming headers")
+        timeout=900)
+    # stream_reader over the live response: never materialises the month
     reader = io.TextIOWrapper(
-        zstandard.ZstdDecompressor().stream_reader(io.BytesIO(raw)),
+        zstandard.ZstdDecompressor().stream_reader(resp),
         encoding="utf-8", errors="replace")
     games, cur = [], {}
     for line in reader:
@@ -41,7 +58,12 @@ def main():
                               cur.get("Result"), cur.get("ECO"),
                               cur.get("WhiteElo"), cur.get("BlackElo"),
                               cur.get("Event", "")))
+                if MAX_GAMES and len(games) >= MAX_GAMES:
+                    break
+                if len(games) % 500_000 == 0:
+                    print(f"  {len(games)} games", flush=True)
             cur = {}
+    resp.close()
     df = pd.DataFrame(games, columns=["white", "black", "result", "eco",
                                       "welo", "belo", "event"])
     df.to_parquet(CACHE)

--- a/tests/test_correlated_updates.py
+++ b/tests/test_correlated_updates.py
@@ -109,3 +109,26 @@ def test_laplace_updates_shrink_variance():
     assert var.max() <= 1.0 + 1e-9, var.max()
     assert var.mean() < 0.35, var.mean()
     assert np.corrcoef(-mean, a)[0, 1] > 0.8
+
+
+def test_node_count_parameters_apply_where_documented():
+    # rank >= 3: Qf is inert (it was silently ignored: the Sobol count
+    # was hard-coded at 1024), nodes_log2 is the knob, and the default
+    # reproduces the historical count
+    rng = np.random.default_rng(4)
+    m = rng.normal(size=4); v = np.full(4, 0.9)
+    V = rng.normal(0, 0.4, (4, 3))
+    a = update_winner_correlated(m, v, 1, V, Qf=3)
+    b = update_winner_correlated(m, v, 1, V, Qf=7)
+    assert np.abs(a[0] - b[0]).max() == 0.0 and a[2] == b[2]
+    c = update_winner_correlated(m, v, 1, V, nodes_log2=8)
+    d = update_winner_correlated(m, v, 1, V)
+    e = update_winner_correlated(m, v, 1, V, nodes_log2=10)
+    assert np.abs(c[0] - d[0]).max() > 0.0                # the knob acts
+    assert np.abs(c[0] - d[0]).max() < 2e-2               # and converges
+    assert np.abs(d[0] - e[0]).max() == 0.0 and d[2] == e[2]
+    # rank <= 2: Qf is the knob
+    V2 = V[:, :2]
+    f = update_winner_correlated(m, v, 1, V2, Qf=3)
+    g = update_winner_correlated(m, v, 1, V2, Qf=7)
+    assert np.abs(f[0] - g[0]).max() > 0.0

--- a/winning/likelihood.py
+++ b/winning/likelihood.py
@@ -124,13 +124,17 @@ def choice_loglik_and_score(mu, V, choice, D=None, Qf=7, Qz=7):
     return loglik, dmu, dV
 
 
-def _factor_nodes(r, Qf=7):
+def _factor_nodes(r, Qf=7, nodes_log2=10):
     """(F, W) over the factor space alone (no own-noise dimension): the
     Gumbel members condition only on f, the winner integral being closed
-    form. GH tensor for r <= 2, Sobol beyond."""
+    form. Gauss-Hermite tensor with Qf nodes per dimension at r <= 2;
+    2**nodes_log2 scrambled Sobol nodes at r >= 3, where Qf is inert
+    (it was silently ignored there until 2026-09-11: the count was
+    hard-coded at 1024, so the parameter did nothing in exactly the
+    regime a user would reach for it)."""
     if r > 2:
         from scipy.stats import qmc
-        n = 2 ** 10
+        n = 2 ** int(nodes_log2)
         u = qmc.Sobol(r, scramble=True, seed=0).random(n)
         return ndtri(np.clip(u, 1e-12, 1 - 1e-12)), np.full(n, 1.0 / n)
     xf, wf = _gh1(Qf)
@@ -144,7 +148,8 @@ def _factor_nodes(r, Qf=7):
     return F, W / W.sum()
 
 
-def ranking_loglik_and_score(mu, V, orders, temperature=1.0, Qf=7):
+def ranking_loglik_and_score(mu, V, orders, temperature=1.0, Qf=7,
+                             nodes_log2=10):
     """Mixed Plackett--Luce log-likelihood of (partial) rankings, with
     analytic score in mu and V: the likelihood member the ranking-bias
     result demanded.
@@ -181,7 +186,7 @@ def ranking_loglik_and_score(mu, V, orders, temperature=1.0, Qf=7):
     T, J = mu.shape
     r = V.shape[1]
     tau = float(temperature)
-    F, W = _factor_nodes(r, Qf=Qf)
+    F, W = _factor_nodes(r, Qf=Qf, nodes_log2=nodes_log2)
     Q = len(F)
     shift = (F @ V.T)                       # (Q, J)
     loglik = 0.0

--- a/winning/ratings/market.py
+++ b/winning/ratings/market.py
@@ -89,7 +89,8 @@ def update_market(m, v, p_market, tau2=0.25, invert=None, **market_model):
 
 
 def update_race(m, v, winner=None, order=None, p_market=None, tau2=0.25,
-                V=None, beta2=1.0, Qf=7, base="normal", **market_model):
+                V=None, beta2=1.0, Qf=7, base="normal", nodes_log2=10,
+                **market_model):
     """The typical race: update from market prices, an outcome, or both
     (prices first -- the market's information is pre-race -- then the
     outcome on the updated prior). Any of winner/order/p_market may be
@@ -119,7 +120,8 @@ def update_race(m, v, winner=None, order=None, p_market=None, tau2=0.25,
     if order is not None:
         if V is not None:
             m, v, lz = update_order_correlated(m, v, order, V, beta2=beta2,
-                                               Qf=Qf, base=base)
+                                               Qf=Qf, base=base,
+                                               nodes_log2=nodes_log2)
             info["logZ_outcome"] = lz
         else:
             m, v = update_ranking_exact(m, v, order, beta2=beta2,
@@ -128,7 +130,8 @@ def update_race(m, v, winner=None, order=None, p_market=None, tau2=0.25,
         if V is not None:
             m, v, lz = update_winner_correlated(m, v, winner, V,
                                                 beta2=beta2, Qf=Qf,
-                                                base=base)
+                                                base=base,
+                                                nodes_log2=nodes_log2)
             info["logZ_outcome"] = lz
         else:
             m, v, p = update_winner(m, v, winner, beta2=beta2, base=base)

--- a/winning/ratings/nway.py
+++ b/winning/ratings/nway.py
@@ -251,7 +251,7 @@ def predictive_win_probabilities(m, v=None, beta2=1.0, base="normal", V=None,
     elif S is not None and B.shape[1] > 0:
         F, W = _mixture_nodes(r, nodes_log2, Qf=9)
     else:
-        F, W = _factor_grid(r, Qf=Qf)          # the diagonal updates' rule
+        F, W = _factor_grid(r, Qf=Qf, nodes_log2=nodes_log2)   # the diagonal updates' rule
     shifts = F @ loads.T
     p = np.zeros(n)
     for q in range(len(W)):
@@ -631,14 +631,15 @@ def order_loglik(m, sd, order, L=2001, base="normal"):
                        base=base)
 
 
-def _factor_grid(r, Qf=7):
-    """Nodes over the shared factors: GH tensor for r <= 2, Sobol past."""
+def _factor_grid(r, Qf=7, nodes_log2=10):
+    """Nodes over the shared factors: Gauss-Hermite tensor (Qf per
+    dimension) at r <= 2, 2**nodes_log2 scrambled Sobol nodes past."""
     from ..likelihood import _factor_nodes
-    return _factor_nodes(r, Qf=Qf)
+    return _factor_nodes(r, Qf=Qf, nodes_log2=nodes_log2)
 
 
 def _mixture_update(m, v, V, beta2, node_logp_grad, Qf=7, eps=1e-3,
-                    base="normal"):
+                    base="normal", nodes_log2=10):
     """Shared engine of the correlated updates. For Gaussian priors,
     E[s_j | event] = m_j + v_j d log P / d m_j and
     Var[s_j | event] = v_j + v_j^2 d^2 log P / d m_j^2 hold for ANY
@@ -652,7 +653,7 @@ def _mixture_update(m, v, V, beta2, node_logp_grad, Qf=7, eps=1e-3,
     V = np.atleast_2d(np.asarray(V, dtype=float))
     if V.shape[0] != len(m):
         V = V.T
-    F, W = _factor_grid(V.shape[1], Qf=Qf)
+    F, W = _factor_grid(V.shape[1], Qf=Qf, nodes_log2=nodes_log2)
     logW = np.log(W)
     shifts = F @ V.T                                  # (Q, n)
 
@@ -690,13 +691,15 @@ def _mixture_update(m, v, V, beta2, node_logp_grad, Qf=7, eps=1e-3,
 
 
 def update_winner_correlated(m, v, winner, V, beta2=1.0, Qf=7, eps=1e-3,
-                             base="normal"):
+                             base="normal", nodes_log2=10):
     """Exact-moment posterior update from `winner` won, when participants
     share performance factors: X_j = s_j + (V f)_j + noise_j,
     f ~ N(0, I_r), noise_j ~ N(0, beta2_j), s_j ~ N(m_j, v_j) (max-wins,
     matching this module throughout). Conditional on f the race is the
     independent one update_winner serves; the update mixes those
-    conditionals with posterior node weights. Returns
+    conditionals with posterior node weights. Nodes: Qf Gauss-Hermite
+    per factor dimension at rank r <= 2; 2**nodes_log2 scrambled Sobol
+    at r >= 3 (Qf is inert there). Returns
     (m_post, v_post, logZ) with logZ = log P(winner) for evidence and
     model comparison. Verified against rejection-sampled Monte Carlo
     posteriors in the tests.
@@ -719,15 +722,18 @@ def update_winner_correlated(m, v, winner, V, beta2=1.0, Qf=7, eps=1e-3,
             g, p = _grad_logp_row(mm, D, winner, base=base)
             return np.log(max(p, 1e-300)), g
 
-    return _mixture_update(m, v, V, beta2, node, Qf=Qf, eps=eps, base=base)
+    return _mixture_update(m, v, V, beta2, node, Qf=Qf, eps=eps, base=base,
+                           nodes_log2=nodes_log2)
 
 
 def update_order_correlated(m, v, order, V, beta2=1.0, Qf=7, eps=1e-3,
-                            base="normal"):
+                            base="normal", nodes_log2=10):
     """The shared-realization-correct full-order update with factor
     correlation: the factor mixture of update_ranking_exact, closing the
     open item recorded in update_ranking's caveat. order lists players
-    first to last finisher (max-wins). Returns (m_post, v_post, logZ),
+    first to last finisher (max-wins). Nodes as in
+    update_winner_correlated (Qf at rank <= 2, 2**nodes_log2 Sobol at
+    rank >= 3). Returns (m_post, v_post, logZ),
     logZ = log P(order). Near-impossible orders degrade like
     order_loglik (finite moments, tiny logZ), never raise.
 
@@ -742,7 +748,8 @@ def update_order_correlated(m, v, order, V, beta2=1.0, Qf=7, eps=1e-3,
     def node(mm):
         return _order_pass(mm, sd, order, base=base, curves=curves)
 
-    return _mixture_update(m, v, V, beta2, node, Qf=Qf, eps=eps, base=base)
+    return _mixture_update(m, v, V, beta2, node, Qf=Qf, eps=eps, base=base,
+                           nodes_log2=nodes_log2)
 
 
 def _order_pass_batch(Ms, sd, order, L=None, base="normal", curves=None):

--- a/winning/ratings/tracker.py
+++ b/winning/ratings/tracker.py
@@ -44,8 +44,9 @@ picked. The consistent fit-and-price CONTROL (winner log-loss unchanged
 under rho) was not carried to its test window and remains open.
 
 Cost: one factor dimension per group of two or more in the contest; two or
-fewer ride a 7^r Gauss-Hermite tensor, more ride 1024 Sobol nodes (about
-15 s per K = 8 field with four groups on one core). Singletons cost nothing.
+fewer ride a 7^r Gauss-Hermite tensor (Qf), more ride 2**nodes_log2 Sobol
+nodes (about 15 s per K = 8 field with four groups on one core; 15-29 s
+for a 20-entrant field with ten pairs). Singletons cost nothing.
 """
 from __future__ import annotations
 
@@ -179,7 +180,17 @@ class AbilityTracker:
                        in common (block_loadings); active only for contests
                        observed or predicted with ``groups``.
     Qf               : Gauss-Hermite nodes per factor dimension for the
-                       block-correlated updates (r <= 2).
+                       block-correlated updates at rank r <= 2 (two groups
+                       of two or more in a contest).
+    nodes_log2       : log2 of the scrambled-Sobol node count at r >= 3,
+                       where Qf is inert. Cost per blocked update goes as
+                       nodes x K^2 and is the real ceiling on block
+                       correlation at double-digit group counts: an F1-shaped
+                       field (20 entrants, 10 two-car teams, r = 10) costs
+                       15-29 s per update at the default 1024 nodes, and
+                       neither update_order_full with a block-diagonal
+                       covariance nor the winner update is cheaper (bandits
+                       measurement, 2026-09-11).
 
     ``evidence`` accumulates log P(observation) over everything observed --
     market prices, scores, orders and winners, independent or blocked -- the
@@ -191,14 +202,14 @@ class AbilityTracker:
                  init_var: float = 4.0, beta2: float = 1.0, tau2: float = 0.25,
                  base: str = "normal", order_method: str = "exact",
                  n_aug: int = 60, burn: int = 20, seed: int = 0,
-                 rho: float = 0.0, Qf: int = 7):
+                 rho: float = 0.0, Qf: int = 7, nodes_log2: int = 10):
         self.drift = float(drift); self.drift_exp = float(drift_exp)
         self.init_var = float(init_var)
         self.beta2 = float(beta2); self.tau2 = float(tau2)
         self.base = base
         if not 0.0 <= float(rho) < 1.0:
             raise ValueError("rho must lie in [0, 1)")
-        self.rho = float(rho); self.Qf = int(Qf)
+        self.rho = float(rho); self.Qf = int(Qf); self.nodes_log2 = int(nodes_log2)
         self.evidence = 0.0
         # order-only observations (no margins) -- 'exact' = winning's exact
         # win-node ranking factor (nway.update_ranking_exact; validated against the
@@ -255,7 +266,8 @@ class AbilityTracker:
             # the belief convolved with the base noise, on the updates'
             # own node rule: predict and evidence agree on every base
             return predictive_win_probabilities(m, v, beta2=b2, base=self.base, V=V,
-                                                Qf=self.Qf, points=points)
+                                                Qf=self.Qf, nodes_log2=self.nodes_log2,
+                                                points=points)
         return race_probabilities(-m, V=V, D=b2 + v, base=self.base, points=points)
 
     # -- observation ---------------------------------------------------------
@@ -301,7 +313,7 @@ class AbilityTracker:
             order = list(order)
             if V is not None:
                 m, v, lz = update_order_correlated(m, v, order, V, beta2=b2, Qf=self.Qf,
-                                                   base=self.base)
+                                                   base=self.base, nodes_log2=self.nodes_log2)
             else:
                 lz = _order_evidence(m, v, order, self.beta2, self.base)
                 if self.order_method == "exact":
@@ -315,7 +327,7 @@ class AbilityTracker:
         elif winner is not None:                                   # winner-only fallback (see order note)
             if V is not None:
                 m, v, lz = update_winner_correlated(m, v, int(winner), V, beta2=b2, Qf=self.Qf,
-                                                    base=self.base)
+                                                    base=self.base, nodes_log2=self.nodes_log2)
             else:
                 m, v, p = update_winner(m, v, int(winner), beta2=self.beta2, base=self.base)
                 lz = float(np.log(max(float(p), 1e-300)))


### PR DESCRIPTION
`Qf` was silently ignored by the correlated updates at factor rank >= 3: `_factor_nodes` hard-coded 1024 scrambled Sobol nodes there, so the parameter did nothing in exactly the regime a user would reach for it (bandits measurement: Qf 2..7 give bit-identical means, variances and evidence at r = 10, K = 20).

The Sobol count is now `nodes_log2` (default 10, the historical count, so results are unchanged by default) on `update_winner_correlated`, `update_order_correlated`, `update_race`, `ranking_loglik_and_score`, `predictive_win_probabilities` and `AbilityTracker`; docstrings say which parameter applies at which rank. A test pins the documented behaviour: Qf inert at rank 3, `nodes_log2` acts and converges, default equals `nodes_log2=10`, Qf acts at rank 2.

The tracker's docstring records the measured cost ceiling of block correlation at double-digit group counts (15-29 s per update for a 20-entrant field with ten pairs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196s5aukyUYtspqTVApwBme