### PR TITLE
research/chess: exp38 reframed as a sparsity study, exp39 registered

### DIFF
--- a/research/chess/README.md
+++ b/research/chess/README.md
@@ -70,17 +70,28 @@ second encodes "I don't know much about this player."
 (`exp37`), but the mechanism's own prediction failed. Rerunning at
 thresholds of 100/50/25/10 games per player:
 
-| threshold | players | games | margin vs Lichess | sparse-player margin |
-|---|---|---|---|---|
-| 100 | 639 | 59,399 | −0.0161 | — |
-| 50 | 1,095 | 83,444 | −0.0170 | −0.0160 |
-| 25 | 1,571 | 97,844 | −0.0190 | −0.0222 |
-| 10 | 2,373 | 109,129 | −0.0157 | −0.0169 |
+| threshold | players | games | obs/param | margin vs Lichess | sparse-player margin |
+|---|---|---|---|---|---|
+| 100 | 639 | 59,399 | 30.9 | −0.0161 | — |
+| 50 | 1,095 | 83,444 | 25.4 | −0.0170 | −0.0160 |
+| 25 | 1,571 | 97,844 | 20.7 | −0.0190 | −0.0222 |
+| 10 | 2,373 | 109,129 | 15.3 | −0.0157 | −0.0169 |
 
 The margin survives a near-4× widening of the population — 639 to
 2,373 players, 59k to 109k games — sitting between −0.016 and −0.019
 throughout, with every interval excluding zero. That is the robustness
 question answered.
+
+The `obs/param` column is the quantitative sparsity axis, and it is
+what makes `exp37` and `exp38` comparable rather than two experiments
+loosely both about "sparsity". Note what `exp37` actually varies:
+lowering the threshold on a *single small month* admits less active
+players while the community stays tightly connected, so it moves
+density only from 30.9 down to 15.3. Modern Lichess sits at **4.61** —
+3.3× beyond `exp37`'s sparsest measured point, and sparse for a
+different reason (players rarely meet, rather than rarely play). So
+`exp37`'s null does not settle what `exp38` will find; it bounds the
+range where the margin is known to be flat.
 
 **But the registered prediction was that the margin would WIDEN
 monotonically as the threshold dropped**, because pooling should pay

--- a/research/chess/README.md
+++ b/research/chess/README.md
@@ -228,8 +228,12 @@ any model is fitted:
   in the *pairing* structure, so no threshold repairs it — restricting
   to the top 639 players by volume makes it *worse* (obs/param 3.84),
   because they are drawn from a 6× larger pool. Nor does more data, at
-  any affordable scale: obs/param scales as games^0.50, so matching
-  30.92 would take ~150–200M games, more than the entire month.
+  any affordable scale: obs/param scales empirically as games^0.50, so
+  even the *full* month (~30× this prefix) projects to ≈25, short of
+  30.92. Matching it outright projects past the month's total size —
+  though that figure extrapolates ~45× beyond the measured range, so
+  the claim worth keeping is the weaker one: downloading the rest of
+  the month would not close the gap.
 
   So `exp38` is not a like-for-like replication and is not written as
   one. It tests the pooling claim in a regime ~7× sparser than the one

--- a/research/chess/README.md
+++ b/research/chess/README.md
@@ -52,6 +52,20 @@ not: colour is worth −0.0016 of the −0.0206 gap, and a colour-blind
 fit still beats colour-blind Glicko-2 by **−0.0190** like-for-like.
 The honest footnote is that ~8% of the estimator column is colour.
 
+**Only one of the two estimators carries its own uncertainty**
+(`exp39`, registered, unrun). Glicko-2 propagates rating deviation
+into every prediction — `win_probabilities` passes each player's RD
+into `gaussian_win_probabilities`, so a player it knows little about
+is pulled toward 0.5. Our arm does not: it prices a MAP point estimate
+with a fixed `D = 1`. The asymmetry is real and should be stated
+before anyone else finds it. It most likely runs *against* us, since a
+proper scoring rule penalises overconfidence, which would make
+−0.0161 an understatement — but that is a belief about a sign, not a
+measurement, and it is not claimed here until `exp39` runs. The
+validation-tuned ridge is not a defence: shrinking the *mean* and
+widening the *predictive* are different operations, and only the
+second encodes "I don't know much about this player."
+
 **The result is not an artifact of the dense subpopulation**
 (`exp37`), but the mechanism's own prediction failed. Rerunning at
 thresholds of 100/50/25/10 games per player:
@@ -171,6 +185,7 @@ failures are kept because they are the transfer conditions:
 | `exp36_colour_confound.py` | is the estimator column just colour? |
 | `exp37_sparse_players.py` | robustness across density thresholds |
 | `exp38_modern_month.py` | 2024-01 replication: registered, unrun |
+| `exp39_predictive_calibration.py` | our overconfidence vs Glicko-2's RD: registered, unrun |
 | `results/` | per-game losses and raw outputs |
 
 Data is one month of the Lichess open database

--- a/research/chess/README.md
+++ b/research/chess/README.md
@@ -211,9 +211,34 @@ any model is fitted:
   favour an arm.
 - **The dimension itself is thinner now.** A population concentrated
   into two adjacent fast controls has less time-control style
-  structure to find than one spread across three. `exp38` therefore
-  pre-registers a *smaller* margin than 2013's −0.0161, and says so
-  before running rather than after.
+  structure to find than one spread across three.
+- **Modern Lichess is far SPARSER, not richer** — the finding that
+  most changes what `exp38` can claim, and the opposite of what I
+  first assumed:
+
+  | | total games | dense players | dense games | obs/param |
+  |---|---|---|---|---|
+  | 2013-01 | 121,332 | 639 | 59,399 | **30.92** |
+  | 2024-01 (4M prefix) | 3,293,889 | 3,847 | 53,248 | **4.61** |
+
+  The dense-subgraph filter keeps 50.7% of 2013's month and 1.6% of
+  2024's. 2013 Lichess was a small, tightly connected community whose
+  active players met each other repeatedly; modern Lichess is so large
+  that even its most active players rarely meet twice. The sparsity is
+  in the *pairing* structure, so no threshold repairs it — restricting
+  to the top 639 players by volume makes it *worse* (obs/param 3.84),
+  because they are drawn from a 6× larger pool. Nor does more data, at
+  any affordable scale: obs/param scales as games^0.50, so matching
+  30.92 would take ~150–200M games, more than the entire month.
+
+  So `exp38` is not a like-for-like replication and is not written as
+  one. It tests the pooling claim in a regime ~7× sparser than the one
+  that established it. Its falsification clause separates the two
+  explanations a negative could have — if the estimator column
+  survives and only the structure column dies, that is sparsity and
+  the factor claim is bounded to denser regimes; if both die, the
+  headline is a 2013 finding. Reporting one as the other is the
+  specific error the registration exists to prevent.
 
 `loader.py` now streams the HTTP response straight into the zstd
 decoder and takes a cap, because a modern month is ~32 GB compressed

--- a/research/chess/exp38_modern_month.py
+++ b/research/chess/exp38_modern_month.py
@@ -50,11 +50,18 @@ repairs it -- restricting to the top 639 players by volume makes it
 worse, not better (obs/param 3.84), because the pool they are drawn
 from is 6x larger.
 
-Nor does more data repair it at any affordable scale. obs/param scales
-empirically as games^0.50 here, so matching 30.92 would need roughly
-150-200M games -- more than the entire month. The community grew far
-faster than any individual's game count, and that is a permanent fact
-about modern Lichess, not a property of this 4M prefix.
+Nor does more data repair it at any affordable scale. Across prefixes
+of the cached month obs/param scales empirically as games^0.50, so the
+FULL month (~95-100M games, about 30x this prefix) projects to roughly
+25 -- still short of 30.92, and that is a 30x extrapolation from a fit
+whose two smallest points are thin. Matching 30.92 outright projects
+to 150-200M games, more than the month contains, but that figure
+extrapolates ~45x beyond the measured range and should be read as an
+order of magnitude rather than a number. The robust claim is the
+weaker one: downloading the rest of the month would not close this
+gap. The community grew far faster than any individual's game count,
+and that is a permanent fact about modern Lichess, not a property of
+this 4M prefix.
 
 So this experiment tests the pooling claim in a regime ~7x sparser
 than the one it was established in. That is a harder test, not a

--- a/research/chess/exp38_modern_month.py
+++ b/research/chess/exp38_modern_month.py
@@ -75,12 +75,20 @@ here, which is why this is worth running:
       pooling thesis (exp28e: advantage monotone in cell sparsity)
       predicts the margin WIDENS, because pooling pays most when data
       per cell is scarce, and this is the scarcest regime yet tested.
-      But exp37 tested exactly that prediction in chess and it FAILED
-      -- the margin did not widen as players got sparser. I do not get
-      to claim both. I predict the margin does NOT widen, siding with
-      the measured chess evidence over the theory, and if it widens
-      then exp37's null was the anomaly and the pooling story is
-      stronger than the chess data has so far shown.
+      But exp37 tested that prediction in chess and it FAILED -- the
+      margin did not widen as players got sparser. I do not get to
+      claim both. I predict the margin does NOT widen, siding with the
+      measured chess evidence over the theory, and if it widens then
+      exp37's null was the anomaly and the pooling story is stronger
+      than the chess data has so far shown.
+      The tension is real but NOT a straight contradiction, and the
+      difference matters. exp37 lowered the threshold on one small
+      month, which admits less active players while the community
+      stays tightly connected; it moved obs/param only from 30.9 to
+      15.3. This sits at 4.61 -- 3.3x beyond exp37's sparsest measured
+      point, and sparse for a different reason (players rarely MEET
+      rather than rarely play). exp37's null bounds the range where
+      the margin is known flat; it does not extend to here.
       Working against both: classical has nearly vanished, so there is
       less time-control structure of any kind left to find.
   P3. The estimator/structure split still favours the estimator

--- a/research/chess/exp38_modern_month.py
+++ b/research/chess/exp38_modern_month.py
@@ -34,18 +34,67 @@ same split. Changing the reference level of a saturated set of
 category offsets cannot favour an arm, because the fitted ability
 differences are invariant to it.
 
-PRE-REGISTERED PREDICTIONS:
+THIS IS NOT A DENSITY-MATCHED REPLICATION, and pretending otherwise
+would make the result uninterpretable. Measured before running:
+
+                    total games   dense players   dense games   obs/param
+    2013-01             121,332             639        59,399       30.92
+    2024-01 (4M)      3,293,889           3,847        53,248        4.61
+
+The dense-subgraph filter keeps **50.7%** of 2013's month and **1.6%**
+of 2024's. 2013 Lichess was a small, tightly connected community where
+the active players met each other repeatedly; by 2024 the site is so
+large that even its most active players rarely meet twice. The
+sparsity is in the PAIRING structure, not in activity, so no threshold
+repairs it -- restricting to the top 639 players by volume makes it
+worse, not better (obs/param 3.84), because the pool they are drawn
+from is 6x larger.
+
+Nor does more data repair it at any affordable scale. obs/param scales
+empirically as games^0.50 here, so matching 30.92 would need roughly
+150-200M games -- more than the entire month. The community grew far
+faster than any individual's game count, and that is a permanent fact
+about modern Lichess, not a property of this 4M prefix.
+
+So this experiment tests the pooling claim in a regime ~7x sparser
+than the one it was established in. That is a harder test, not a
+lesser one, and it is the reason the predictions below are genuinely
+uncertain rather than a formality.
+
+PRE-REGISTERED PREDICTIONS, and two of my own results are in tension
+here, which is why this is worth running:
   P1. The factor rating still beats glicko2-per-TC, CI excluding zero.
-  P2. The margin is SMALLER than 2013's 0.0161. Two reasons pull that
-      way: with classical nearly gone the population is more
-      homogeneous in time control, so there is less style structure to
-      find; and a 7x larger player pool means more data per parameter
-      for every arm, which helps the competitor too.
+  P2. DIRECTION UNCERTAIN, stated as a fork rather than a guess. The
+      pooling thesis (exp28e: advantage monotone in cell sparsity)
+      predicts the margin WIDENS, because pooling pays most when data
+      per cell is scarce, and this is the scarcest regime yet tested.
+      But exp37 tested exactly that prediction in chess and it FAILED
+      -- the margin did not widen as players got sparser. I do not get
+      to claim both. I predict the margin does NOT widen, siding with
+      the measured chess evidence over the theory, and if it widens
+      then exp37's null was the anomaly and the pooling story is
+      stronger than the chess data has so far shown.
+      Working against both: classical has nearly vanished, so there is
+      less time-control structure of any kind left to find.
   P3. The estimator/structure split still favours the estimator
       (2013: ~80% estimator, ~20% structure).
-  FALSIFICATION: if the factor rating does not beat glicko2-per-TC on
-  modern data, the headline is a 2013 artifact and must be restated as
-  such.
+
+  FALSIFICATION, and the distinction that makes it meaningful: if the
+  factor rating does not beat glicko2-per-TC, that is NOT automatically
+  "the 2013 headline was an artifact." Sparsity and era are two
+  different explanations and the decomposition separates them:
+
+    - if `our scalar` still beats `glicko2 pooled` (the ESTIMATOR
+      column survives) but `factor` no longer beats `our scalar` (the
+      STRUCTURE column vanishes), the cause is sparsity plus the
+      collapse of classical -- there is not enough per-player data to
+      identify three parameters where one will do. The estimator claim
+      stands; the factor claim is bounded to denser regimes.
+    - if BOTH columns vanish, the 2013 result does not survive to the
+      modern era and the headline must be restated as a 2013 finding.
+
+  Reporting a sparsity failure as an era failure, or vice versa, is
+  the specific error this paragraph exists to prevent.
 
 Run:  python research/chess/exp38_modern_month.py
 """
@@ -112,6 +161,9 @@ won = (df.result == "1-0").values
 n = len(df)
 print(f"2024-01 (first 4M games): {n} dense decisive games, {Mp} players")
 print(f"  TC mix: {pd.Series(tcn).value_counts(normalize=True).round(4).to_dict()}")
+_w = Mp * P + NG
+print(f"  obs/param {n/_w:.2f} (2013 was 30.92) -- {30.92/(n/_w):.1f}x sparser;"
+      f" this is NOT a density-matched replication")
 rng = np.random.default_rng(SEED); perm = rng.permutation(n)
 ntr, nva = int(n * .50), int(n * .25)
 tr = np.sort(perm[:ntr])
@@ -172,12 +224,19 @@ for lbl, per in (("glicko2 pooled", False), ("glicko2 per TC", True)):
     best = min(((glicko(tr, va, t, per).mean(), t) for t in (0.3, 0.5)))
     res[lbl] = glicko(tr, te, best[1], per)
     print(f"  {lbl:16s} TEST {res[lbl].mean():.4f}  (tau {best[1]})", flush=True)
-best = min(((ours(tr, va, l, True).mean(), l) for l in (1.0, 3.0)))
+# Grids are wider than 2013's. At obs/param 4.6 rather than 30.9 the
+# optimal penalty must land much higher, and a grid that silently
+# pins at its edge would understate every arm it constrains.
+SCALAR_GRID = (0.3, 1.0, 3.0, 10.0, 30.0)
+FACTOR_GRID = (3.0, 10.0, 30.0, 100.0, 300.0)
+best = min(((ours(tr, va, l, True).mean(), l) for l in SCALAR_GRID))
 res["our scalar"] = ours(tr, te, best[1], True)
-print(f"  {'our scalar':16s} TEST {res['our scalar'].mean():.4f}", flush=True)
-best = min(((ours(tr, va, l).mean(), l) for l in (3.0, 10.0, 30.0)))
+edge = "  <-- GRID EDGE" if best[1] in (SCALAR_GRID[0], SCALAR_GRID[-1]) else ""
+print(f"  {'our scalar':16s} TEST {res['our scalar'].mean():.4f}  "
+      f"(ridge {best[1]}){edge}", flush=True)
+best = min(((ours(tr, va, l).mean(), l) for l in FACTOR_GRID))
 res["factor"] = ours(tr, te, best[1])
-edge = "  <-- grid edge" if best[1] in (3.0, 30.0) else ""
+edge = "  <-- GRID EDGE" if best[1] in (FACTOR_GRID[0], FACTOR_GRID[-1]) else ""
 print(f"  {'factor':16s} TEST {res['factor'].mean():.4f}  (ridge {best[1]})"
       f"{edge}", flush=True)
 

--- a/research/chess/exp39_predictive_calibration.py
+++ b/research/chess/exp39_predictive_calibration.py
@@ -1,0 +1,65 @@
+"""exp39: our arm is overconfident against a competitor that is not.
+
+REGISTERED, NOT YET RUN.
+
+The referee question this answers. Glicko-2 propagates rating
+uncertainty into every prediction -- `win_probabilities` passes each
+player's RD into `gaussian_win_probabilities`, so a player it knows
+little about gets a prediction pulled toward 0.5. Our arm does not. It
+fits a MAP point estimate and prices every game with a fixed unit
+noise, `race_probabilities(-mu, D=ones(2))`. Two estimators are being
+compared while only ONE of them carries its own uncertainty.
+
+That asymmetry is not neutral and it should be stated in whichever
+direction it runs. My expectation is that it runs AGAINST us -- an
+overconfident predictor is penalised by a proper scoring rule, so the
+published margin of -0.0161 would be an understatement. But that is a
+belief about a sign, not a measured fact, and the whole point of the
+programme is to stop asserting those.
+
+Note what is NOT a defence here: the validation-tuned ridge does
+shrink mu toward zero, which reduces overconfidence in aggregate, and
+one could argue calibration is therefore already handled. It is not
+the same thing. Shrinking the MEAN and widening the PREDICTIVE are
+different operations, and only the second represents "I do not know
+much about this player."
+
+ARMS, all sharing the split, the games and the tuned ridge of exp35:
+
+  published     D = 1                       exactly as reported
+  tempered      D = s, s tuned on validation  cheap proxy for the
+                                            missing uncertainty
+  laplace       D = 1 + var(mu_w - mu_b)    the principled version:
+                                            per-parameter posterior
+                                            variance from the diagonal
+                                            of the MAP Hessian
+
+The `laplace` arm is a diagonal approximation and is labelled as one.
+The full Hessian is width x width, and width is 3 x players; at 2013's
+639 players that is tractable and at 2024's 4,389 it is not, so the
+diagonal is what generalises.
+
+FAIRNESS. Tempering our arm is symmetric treatment, not a thumb on the
+scale: Glicko-2's tau is ALREADY tuned on the same validation window
+in every experiment in this directory. Arm `tempered` gives our side
+the one free parameter their side has had all along. If that is judged
+unfair, the honest alternative is to remove tau tuning from Glicko-2
+too, and the comparison should be reported both ways.
+
+PRE-REGISTERED PREDICTIONS:
+  P1. `tempered` beats `published` -- i.e. s* > 1, our arm really was
+      overconfident.
+  P2. The margin over glicko2-per-TC WIDENS relative to -0.0161.
+  P3. `laplace` lands between the two, closer to `tempered`: the
+      diagonal captures most of the missing spread.
+  FALSIFICATION: if s* is at or below 1 and the margin does not widen,
+  then our arm was already well calibrated, P1-P3 are wrong, and the
+  claim "the published margin is conservative because we carry no
+  uncertainty" must be dropped from the README and never repeated. A
+  null here is a perfectly good outcome and costs the headline
+  nothing -- the margin stands either way; only the editorialising
+  about its direction would have to go.
+
+Run:  python research/chess/exp39_predictive_calibration.py [split_seed]
+"""
+raise SystemExit(__doc__)


### PR DESCRIPTION
Four commits by the bandits session, additive under `research/chess/` (they were made on a local branch after PR #33 was pushed; this brings them to main unchanged).

- exp38's premise was backwards and is fixed before running: a modern Lichess month has 6.7x LESS data per parameter (dense-subgraph filter keeps 50.7 percent of 2013-01, 1.6 percent of 2024-01; obs/param 30.9 to 4.6). It is pairing sparsity, so no threshold repairs it and obs/param scales as games^0.5. exp38 is no longer written as a like-for-like replication; its falsification clause separates a sparsity failure from an era failure through the estimator/structure decomposition.
- exp39 registers the uncertainty asymmetry between the arms: Glicko-2 carries RD into every prediction, the factor arm prices a MAP point at fixed D = 1; the sign is a belief, registered rather than claimed.
- The README carries obs/param as an explicit axis so exp37 and exp38 are comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196s5aukyUYtspqTVApwBme