### PR TITLE
Relative finite-difference steps on the diagonal moment updates; factor-fitter bands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- The diagonal moment updates (`update_winner`, `update_ranking_exact`,
+  the correlated mixture) now difference their curvature at steps
+  relative to each coordinate's predictive sd, as the full-covariance
+  path already did, so posterior variances are covariant under a
+  common rescaling of means, prior sds and noise sds (verifier:
+  2.8e-12, was 1.6e-4 at a tenth of unit scale). At unit scale this is
+  the historical step; results move at the fourth decimal.
+- Verifier marks set from the baseline run for the factor fitter's
+  calibration and recovery checks.
 - `Qf` was silently ignored by the correlated updates at factor rank
   >= 3 (`_factor_nodes` hard-coded 1024 Sobol nodes there), so it did
   nothing in exactly the regime a user would reach for it (found by the

--- a/research/adjudications/ratings_verify.md
+++ b/research/adjudications/ratings_verify.md
@@ -141,6 +141,33 @@ Residual, MEASURED: rate_history's order-observation path is an ADF
 projection and stays order-dependent (mean spread 0.022 under a
 permutation of 12 races).
 
+## Gate result (winning session, 2026-09-12, relative finite-difference steps): PASSED
+The diagonal moment updates (update_winner's normal path,
+update_ranking_exact, the correlated mixture) differenced their
+curvature at ABSOLUTE steps (1e-4 winner, 1e-3 orders, 5e-2 on kinked
+bases), so the posterior variances were only approximately covariant
+under a common rescaling of means, prior sds and noise sds, where the
+full-covariance path's relative steps were exact. Steps are now eps
+times each coordinate's predictive sd (the historical step at unit
+scale). identity.invariances.scale_v.diag: 1.6e-4 -> 2.8e-12 (mark
+1e-3 -> 1e-8, set with the change since the identity is exact). Every
+other fast identity holds unchanged (693 ok, 0 FAIL); the enumerated
+moment identities' residuals are within their floors at every cell.
+The legacy audit cells are unchanged to three decimals: update_winner
+robust sd / coverage normal 0.940 / 0.975, gumbel 0.872 / 0.985,
+logistic 0.936 / 0.980, laplace 0.942 / 0.975, student4 0.944 / 0.970,
+failure 0.899 / 0.985 (25 seeds, as in the baseline); the
+update_order_correlated cells pass at their 14 seeds on every base.
+
+## Gate result (winning session, 2026-09-12, factor-fitter bands): set from the baseline
+factor.se_calibration gates at z^2 in [0.85, 1.15] (baseline 0.972 +-
+0.075: the Laplace posterior is calibrated on its own prior);
+factor.recovery_slope at [-0.65, -0.35] (baseline -0.41, the n^-1/2 law
+of a regular MAP). factor.heldout stays MEASURED: its margins are
+world-specific, and its falsification clause (normal trailing
+Plackett-Luce on normal-generated data by more than two paired SE)
+already fails on its own.
+
 ## Open items entering the ledger as MEASURED (2026-09-11)
 
 - identity.invariances.scale_v on the diagonal paths: absolute

--- a/winning/ratings/nway.py
+++ b/winning/ratings/nway.py
@@ -323,14 +323,20 @@ def update_winner(m, v, winner, beta2=1.0, eps=1e-4, base="normal"):
     g, p_i = _grad_logp_row(m, D, winner, base=base)
     m_new = m + v * g
     # diagonal second derivatives by per-coordinate central differences of
-    # the gradient row (analytic second-order pass is a known follow-up)
+    # the gradient row (analytic second-order pass is a known follow-up).
+    # The step is RELATIVE, eps times the coordinate's predictive sd: an
+    # absolute step made the variances only approximately scale-covariant
+    # (verifier, 2026-09-11: 1.6e-4 at a tenth of unit scale) where the
+    # full-covariance path's relative steps are covariant to 1e-8; at
+    # unit scale this is the historical step.
     eps = _fd_eps(base, eps)
+    step = eps * np.sqrt(D)
     d2 = np.empty(len(m))
     for j in range(len(m)):
-        ej = np.zeros(len(m)); ej[j] = eps
+        ej = np.zeros(len(m)); ej[j] = step[j]
         gp, _ = _grad_logp_row(m + ej, D, winner, base=base)
         gm, _ = _grad_logp_row(m - ej, D, winner, base=base)
-        d2[j] = (gp[j] - gm[j]) / (2 * eps)
+        d2[j] = (gp[j] - gm[j]) / (2 * step[j])
     d2 = _clamp_d2(d2, base)
     v_new = np.maximum(v + v**2 * d2, 1e-6)
     return m_new, v_new, p_i
@@ -594,12 +600,13 @@ def update_ranking_exact(m, v, order, beta2=1.0, eps=1e-3,
     m_new = m + v * grad
     if curves is None:
         eps = _fd_eps(base, eps)
+    step = eps * sd                      # relative to the predictive sd (scale-covariant)
     d2 = np.empty(len(m))
     for j in range(len(m)):
-        ej = np.zeros(len(m)); ej[j] = eps
+        ej = np.zeros(len(m)); ej[j] = step[j]
         _, gp = _order_pass(m + ej, sd, order, base=base, curves=curves)
         _, gm = _order_pass(m - ej, sd, order, base=base, curves=curves)
-        d2[j] = (gp[j] - gm[j]) / (2 * eps)
+        d2[j] = (gp[j] - gm[j]) / (2 * step[j])
     d2 = _clamp_d2(d2, base)
     v_new = np.clip(v + v ** 2 * d2, 1e-4, None)
     return m_new, v_new
@@ -678,13 +685,13 @@ def _mixture_update(m, v, V, beta2, node_logp_grad, Qf=7, eps=1e-3,
     # no _fd_eps widening here: both callers route every non-normal base
     # through _predictive_curves nodes, whose Gaussian-smoothed marginals
     # have no kink for the differencing step to trip on
-    eps = float(eps)
+    step = float(eps) * np.sqrt(v + _beta_per_player(beta2, len(m)))   # relative steps
     d2 = np.empty(len(m))
     for j in range(len(m)):
-        ej = np.zeros(len(m)); ej[j] = eps
+        ej = np.zeros(len(m)); ej[j] = step[j]
         gp, _ = mixture(m + ej)
         gm, _ = mixture(m - ej)
-        d2[j] = (gp[j] - gm[j]) / (2 * eps)
+        d2[j] = (gp[j] - gm[j]) / (2 * step[j])
     d2 = _clamp_d2(d2, base)
     v_new = np.clip(v + v ** 2 * d2, 1e-4, None)
     return m_new, v_new, float(logZ)

--- a/winning/ratings/verify/marks.py
+++ b/winning/ratings/verify/marks.py
@@ -172,16 +172,17 @@ MARKS = {
     "identity.invariances.scale_m": {"tolerance": 1e-8, "set_by": "planning pilots",
                                      "date": "2026-09-11",
                                      "basis": "lattice built in sd units; evidence scale-free"},
-    # variances under scaling: the full path differences at relative
-    # steps and is covariant to fp (6.5e-8); the diagonal paths use
-    # ABSOLUTE steps (1e-4 winner, 1e-3 orders), so their curvature
-    # error grows as the scale shrinks (1.6e-4 at c = 0.1 on logistic
-    # orders) -- a documented cost, candidate for relative steps
+    # variances under scaling: every path now differences at steps
+    # relative to the coordinate's predictive sd. The diagonal paths
+    # used ABSOLUTE steps (1e-4 winner, 1e-3 orders) until 2026-09-12,
+    # with curvature error growing as the scale shrank (1.6e-4 at
+    # c = 0.1 on logistic orders); after the change they are covariant
+    # to 2.8e-12, the full path to 6.5e-8 (batched lattice endpoints)
     "identity.invariances.scale_v.full": {"tolerance": 1e-6, "set_by": "planning pilots",
                                           "date": "2026-09-11", "basis": "relative FD steps"},
-    "identity.invariances.scale_v.diag": {"tolerance": 1e-3, "set_by": "planning pilots",
-                                          "date": "2026-09-11",
-                                          "basis": "absolute FD steps; 1.6e-4 at c=0.1"},
+    "identity.invariances.scale_v.diag": {"tolerance": 1e-8, "set_by": "relative-step adjudication",
+                                          "date": "2026-09-12",
+                                          "basis": "relative FD steps; measured 2.8e-12 (was 1.6e-4)"},
     "identity.invariances.exact": {"tolerance": 1e-12, "set_by": "planning pilots",
                                    "date": "2026-09-11", "basis": "identical code path"},
     "identity.predict_evidence.normal": {"tolerance": 1e-8, "set_by": "planning pilots",
@@ -259,6 +260,17 @@ MARKS = {
                           "basis": "5.7e-5 / 12 relative on the mixed events"},
     "factor.hessian_spd": {"tolerance": 1e-10, "set_by": "planning pilots", "date": "2026-09-11",
                            "basis": "symmetric to fp; ridge keeps it positive definite"},
+
+    # the MAP fitter's behavioural checks, bands set from the baseline
+    # run (2026-09-11, 25121e0): Laplace SBC on the ridge prior z^2
+    # 0.972 +- 0.075 at 30 worlds; recovery slope -0.41 over n in
+    # {200, 800, 3200}; leakage guard positive control 0.087 +- 0.012
+    "factor.se_calibration": {"z2_band": (0.85, 1.15), "set_by": "baseline adjudication",
+                              "date": "2026-09-12",
+                              "basis": "Laplace posterior calibrated on its prior; 30 worlds x 40 z"},
+    "factor.recovery_slope": {"band": (-0.65, -0.35), "set_by": "baseline adjudication",
+                              "date": "2026-09-12",
+                              "basis": "RMSE ~ n^-1/2 for a regular MAP; measured -0.41"},
 }
 
 # documented approximation costs: name -> {"envelope", "cite", "why"};


### PR DESCRIPTION
The diagonal moment updates (`update_winner`'s normal path, `update_ranking_exact`, the correlated mixture) differenced their curvature at absolute steps, so posterior variances were only approximately covariant under a common rescaling of means, prior sds and noise sds (verifier `identity.invariances.scale_v.diag`: 1.6e-4 at a tenth of unit scale) where the full-covariance path's relative steps were covariant to 1e-8. Steps are now eps times each coordinate's predictive sd, the historical step at unit scale.

Acceptance, by the verifier: scale covariance 2.8e-12 (mark moved 1e-3 to 1e-8 with the change, since the identity is exact); every other fast identity unchanged (693 ok, 0 FAIL); the legacy audit cells unchanged to three decimals; full suite green locally. Ledger entry recorded.

Also sets the factor fitter's bands from the baseline run (`factor.se_calibration` z^2 in [0.85, 1.15]; `factor.recovery_slope` in [-0.65, -0.35]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196s5aukyUYtspqTVApwBme