### PR TITLE
Block correlation: state what the code does and what was measured; predictive claim withdrawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,14 @@ limit; `covariate_contrast_report` checks that the covariate is
 assigned rather than chosen, since a null on a self-selected covariate
 means unidentifiable, not absent. Block correlation
 (`AbilityTracker(rho=...)` with `groups`, `tune_block_rho`) gives
-same-team entrants a shared performance component, fitted and priced
-under one model, with the correlation share selected by the filter's
-own evidence — on Formula 1 it prices the same-team 1–2 finish that no
-scalar or pairwise rating can express. The measurements and the
-open control are on the [ratings page](https://winning.microprediction.org/ratings.html).
+same-group entrants a shared per-contest shock, fitted and priced under
+one model, with the correlation share selected by the filter's own
+evidence; the component is redrawn every contest, and a persistent
+group advantage belongs in the means instead. The Formula 1 test that
+motivated it withdrew its predictive claim (the correlation is in the
+data; the held-out winner log-loss got worse), and the [ratings
+page](https://winning.microprediction.org/ratings.html) says so without
+claiming a mechanism.
 
 ## History
 

--- a/docs/ratings.html
+++ b/docs/ratings.html
@@ -147,25 +147,34 @@
 covariate_contrast_report(events, n_entities, n_cov=3)["ratio"]   # near 1: assigned; far above: chosen
 B = fit_factor_ratings(events, n_entities, n_cov=3, ridge=[1.0, 30.0, 30.0])
 predict_factor(B, subset=[3, 7], x=[1, 0, 1])                       # win probabilities under blitz</code></pre>
-    <p>The second entry point is block correlation, where the engine is
-      doing something no scalar or pairwise rating can express. Teammates
-      share a car, a crew shares a boat: same-group entrants have a
-      shared component of performance, and at twenty entrants that
-      restructures the whole ordering distribution. <code>AbilityTracker</code>
-      accepts <code>groups</code> with a contest and a correlation share
-      <code>rho</code>, variance-preserving so every marginal keeps its
-      scale; observation and prediction use the same loadings, and
-      <code>tune_block_rho</code> selects <code>rho</code> by the filter's
-      own evidence, the sum of log P(observation) every update returns,
-      without consulting any target event. On Formula 1 the same-team 1&ndash;2
-      rate is 0.274 observed against 0.123 under independence and 0.190
-      at <code>rho</code> = 0.4, a joint log-loss improvement of
-      &minus;0.0714 [&minus;0.1228, &minus;0.0235]; training evidence
-      prefers 0.4 to independence by 28.8 nats over 158 races, the value
-      that validation on the joint event also picked. One measurement is
-      open: the consistent fit-and-price control (winner log-loss
-      unchanged under <code>rho</code>) has not been carried to its test
-      window.</p>
+    <p>The second entry point is block correlation: same-group entrants
+      share a component of performance that is redrawn at every contest,
+      and at twenty entrants that restructures the whole ordering
+      distribution. <code>AbilityTracker</code> accepts <code>groups</code>
+      with a contest and a correlation share <code>rho</code>,
+      variance-preserving so every marginal keeps its scale; observation
+      and prediction use the same loadings, and <code>tune_block_rho</code>
+      selects <code>rho</code> by the filter's own evidence without
+      consulting any target event. The shared component is a mean-zero
+      draw redrawn at every contest; a persistent group advantage is a
+      different object and belongs in the means (a group column in the
+      design of <code>fit_design_ratings</code>). The Formula 1 test that
+      motivated the feature is the caution: the correlation is in the
+      data (training evidence prefers <code>rho</code> = 0.4 to
+      independence by 28.7 nats over 158 races; same-team 1&ndash;2 finishes
+      0.274 observed against 0.123 under independence), yet fitted and
+      priced consistently under the blocked likelihood the held-out
+      winner log-loss was worse by +0.053 [+0.019, +0.087] over 106 races,
+      and the joint same-team advantage fell to &minus;0.019 [&minus;0.052,
+      +0.011] and is withdrawn. The signature is confident mis-ranking
+      rather than blurring: the mean probability on the actual winner
+      barely moves while the spread of log probabilities widens, so the
+      loss sits in a minority of confident misses; the two mechanisms
+      tested on that output (persistent team quality forced through the
+      per-race draw; smearing toward uniform) were both rejected, so none
+      is claimed. No performance claim is made for the feature in either
+      direction; the open question is a persistent group term in the mean
+      fitted alongside <code>rho</code>.</p>
 <pre><code>from winning.ratings import AbilityTracker, tune_block_rho
 
 sel = tune_block_rho(contests, rho_grid=(0.0, 0.2, 0.4, 0.6), drift=0.03)

--- a/winning/ratings/tracker.py
+++ b/winning/ratings/tracker.py
@@ -27,21 +27,35 @@ observed and its noise:
 If only a finishing order is known (no magnitudes), the exact N-way Thurstone
 factor (``nway``) is used for that observer instead.
 
-BLOCK CORRELATION (same-group entrants). Teammates share a car; a crew shares
-a boat. Pass ``groups`` with a contest and set ``rho`` and every observer
-prices the blocked model, variance-preserving: x_j = s_j + sqrt(rho beta2)
-z_g(j) + sqrt((1 - rho) beta2) eps_j, so each marginal keeps variance beta2
-and only the joint changes. Fit and prediction use the same V, which is the
-consistency an earlier measurement lacked (fitted independent, priced
-correlated: a +0.017 winner-control residual). rho is selected by the
-filter's own evidence, ``tune_block_rho`` -- the sum of log P(observation)
-every update already returns -- which never sees a target event. Measured on
-Formula 1 (bandits exp33/exp34): same-team 1-2 rate 0.274 observed against
-0.123 under independence and 0.190 at rho = 0.4; joint log-loss -0.0714
-[-0.1228, -0.0235]; training evidence prefers rho = 0.4 to independence by
-28.8 nats over 158 races, the same value validation on the joint event
-picked. The consistent fit-and-price CONTROL (winner log-loss unchanged
-under rho) was not carried to its test window and remains open.
+BLOCK CORRELATION (same-group entrants). Pass ``groups`` with a contest and
+set ``rho`` and every observer prices the blocked model, variance-
+preserving: x_j = s_j + sqrt(rho beta2) z_g(j) + sqrt((1 - rho) beta2) eps_j,
+so each marginal keeps variance beta2 and only the joint changes. Fit and
+prediction use the same V. rho is selected by the filter's own evidence,
+``tune_block_rho`` -- the sum of log P(observation) every update already
+returns -- which never sees a target event.
+
+WHAT THE CODE DOES, and what is measured. The shared component z_g is
+redrawn at every contest, a mean-zero draw common to the group's members
+in that contest; a persistent group advantage is a different object and
+belongs in the means (a group column in the design of fit_design_ratings,
+or a shared offset), whatever this term is set to. The Formula 1
+measurement that motivated the feature (bandits exp33 / exp34,
+2026-09-12) is the caution: teammates share a car and the data carry the
+correlation (training evidence prefers rho = 0.4 to independence by 28.7
+nats over 158 races; same-team 1-2 finishes 0.274 observed against 0.123
+under independence), yet fitted and priced consistently under the blocked
+likelihood the winner log-loss on 106 held-out races was WORSE by +0.053
+[+0.019, +0.087], and the joint same-team advantage fell to -0.019
+[-0.052, +0.011] and is withdrawn. The signature is confident
+mis-ranking rather than blurring: the mean probability on the actual
+winner barely moves (0.319 to 0.311) while the spread of log
+probabilities widens, so the loss sits in a minority of confident misses.
+Two mechanisms were tested and rejected on that output -- damage does not
+concentrate in races won by persistently strong teams, and predictions
+do not smear toward uniform -- so no mechanism is claimed. No performance
+claim is made for this feature in either direction; the open question is
+a persistent group term in the mean fitted alongside rho.
 
 Cost: one factor dimension per group of two or more in the contest; two or
 fewer ride a 7^r Gauss-Hermite tensor (Qf), more ride 2**nodes_log2 Sobol
@@ -390,9 +404,12 @@ def tune_block_rho(contests: Sequence[dict], rho_grid=(0.0, 0.1, 0.25, 0.4, 0.6)
     either end of the grid is a capped rival, not a tuned one; widen the
     grid. ``params`` go to AbilityTracker (drift, beta2, base, Qf, ...).
 
-    Two independent criteria picked the same value on Formula 1: this
-    evidence and validation on the same-team 1-2 statistic both chose 0.4.
-    Cost: one blocked walk per grid point (module docstring)."""
+    On Formula 1 this evidence preferred rho = 0.4 to independence by
+    28.7 nats -- the correlation is in the data -- and the blocked model
+    still predicted held-out winners worse (module docstring). A
+    likelihood ratio says the structure is present, not that pricing it
+    this way predicts better. Cost: one blocked walk per grid point
+    (module docstring)."""
     evidence = []
     for rho in rho_grid:
         trk = AbilityTracker(rho=float(rho), **params)


### PR DESCRIPTION
Docs only. The Formula 1 control (bandits exp34, 2026-09-12) failed: fitted and priced consistently under the blocked likelihood, the held-out winner log-loss over 106 races was worse by +0.053 [+0.019, +0.087], and the joint same-team advantage fell from -0.0714 to -0.019 [-0.052, +0.011], its registered falsification. The correlation is in the data (28.7 nats in-sample; 0.274 vs 0.123 same-team 1-2 finishes). The signature is confident mis-ranking rather than blurring; two candidate mechanisms tested on the output were rejected, so none is claimed.

The tracker docstring, the ratings docs page and the README now say only what the code does (a mean-zero shared draw redrawn every contest; persistent group quality belongs in the means), what was measured, that no performance claim is made in either direction, and the open question (a persistent group term fitted alongside rho).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196s5aukyUYtspqTVApwBme